### PR TITLE
Add install instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Features
 
 
 
+Install
+----------------------------------
+
+```
+npm install @jsdevtools/readdir-enhanced
+```
+
+
+
 Example
 ----------------------------------
 


### PR DESCRIPTION
Closes #19

Using `@jsdevtools/readdir-enhanced` instead of `readdir-enhanced` as explained in https://github.com/JS-DevTools/readdir-enhanced/issues/22#issuecomment-664419363